### PR TITLE
Fixed Support for WebAudioPlugin on PhoneGap-Apps

### DIFF
--- a/src/soundjs/WebAudioPlugin.js
+++ b/src/soundjs/WebAudioPlugin.js
@@ -81,7 +81,9 @@ this.createjs = this.createjs || {};
 	 * @static
 	 */
 	s.isSupported = function () {
-        if (location.protocol == "file:") { return false; }  // Web Audio requires XHR, which is not available locally
+		// check if this is some kind of mobile device, Web Audio works with local protocol under PhoneGap
+		var isMobilePhoneGap = ( navigator.userAgent.toLowerCase().match(/(ipad|iphone|ipod|android|blackberry)/g) ? true : false );
+    if (location.protocol == "file:" && !isMobilePhoneGap) { return false; }  // Web Audio requires XHR, which is not available locally
 		s.generateCapabilities();
 		if (s.context == null) {
 			return false;


### PR DESCRIPTION
In PhoneGap Apps the `location.protocol` equals `'file:'`, however the Web Audio does not require XHR if used through PhoneGap, so I added an additional Line to check if this is a Mobile device.
###### Note

I did ONLY test this on an iPad since I do not have any other devices for testing.
