### PR TITLE
Fixed support for URIs with query strings

### DIFF
--- a/src/soundjs/Sound.js
+++ b/src/soundjs/Sound.js
@@ -911,16 +911,10 @@ this.createjs = this.createjs || {};
 		if (!s.initializeDefaultPlugins()) {
 			return s.defaultSoundInstance;
 		}
+		src = s.getSrcById(src);
 		var details = s.parsePath(src, "sound");
-		if (details) {
-			src = s.getSrcById(details.src);
-		} else {
-			src = s.getSrcById(src);
-		}
 
-		var dot = src.lastIndexOf(".");
-		var ext = src.slice(dot + 1);  // sound have format of "path+name . ext"
-		if (dot != -1 && s.SUPPORTED_EXTENSIONS.indexOf(ext) > -1) {  // we have an ext and it is one of our supported,Note this does not mean the plugin supports it.  // OJR consider changing to check against activePlugin.capabilities[ext]
+		if (details) {
 			// make sure that we have a sound channel (sound is registered or previously played)
 			SoundChannel.create(src);
 


### PR DESCRIPTION
Sound.createInstance was using everything after the last '.' as the file
extension. This meant that any query strings in the URI would be
considered part of the extension and the file would then be considered
to be unsupported.

This has been fixed by using Sound.parsePath to determine whether src
is supported or not. This also resolves the issue where the current
plugin does not support the extension because Sound.parsePath checks
both the supported extensions as well as the current plugin's capabilities.
