### PR TITLE
Fix play function: duration is taken as startTime

### DIFF
--- a/src/soundjs/Sound.js
+++ b/src/soundjs/Sound.js
@@ -1028,7 +1028,7 @@ this.createjs = this.createjs || {};
 			loop = interrupt.loop;
 			volume = interrupt.volume;
 			pan = interrupt.pan;
-			startTime = interrupt.duration;
+			startTime = interrupt.startTime;
 			duration = interrupt.duration;
 			interrupt = interrupt.interrupt;
 


### PR DESCRIPTION
Only happens, when play function is configured with an object...
