### PR TITLE
WebAudio disconnect() method accepts an integer parameter, not an object...

### DIFF
--- a/src/soundjs/WebAudioPlugin.js
+++ b/src/soundjs/WebAudioPlugin.js
@@ -851,7 +851,7 @@ this.createjs = this.createjs || {};
 	p._cleanUpAudioNode = function(audioNode) {
 		if(audioNode) {
 			audioNode.stop(0);
-			audioNode.disconnect(this.panNode);
+			audioNode.disconnect(0);
 			audioNode = null;
 		}
 		return audioNode;


### PR DESCRIPTION
.... This resolves an issue with an exception being thrown on the HTC one (android 4.2), causing the sound complete event to never fire.
