### PR TITLE
Fix for loadItem

### DIFF
--- a/src/soundjs/Sound.js
+++ b/src/soundjs/Sound.js
@@ -936,7 +936,7 @@ this.createjs = this.createjs || {};
 		loadItem = createjs.LoadItem.create(loadItem);
 		loadItem.path = basePath;
 
-		if (basePath != null && !(loadItem.src instanceof Object)) {loadItem.src = basePath + src;}
+		if (basePath != null && !(loadItem.src instanceof Object)) {loadItem.src = basePath + loadItem.src;}
 
 		var loader = s._registerSound(loadItem);
 		if(!loader) {return false;}


### PR DESCRIPTION
createjs.Sound.registerSound was producing errors when the src is an
object. This is because the original src is used and not the parsed
load item src.

