### PR TITLE
Fixed Chrome issue with WebAudio only playing right channel

### DIFF
--- a/src/soundjs/webaudio/WebAudioSoundInstance.js
+++ b/src/soundjs/webaudio/WebAudioSoundInstance.js
@@ -76,6 +76,7 @@ this.createjs = this.createjs || {};
 		this.panNode = s.context.createPanner();
 		this.panNode.panningModel = s._panningModel;
 		this.panNode.connect(this.gainNode);
+		this._updatePan();
 
 		/**
 		 * NOTE this is only intended for use by advanced users.


### PR DESCRIPTION
We failed to initialize the pan node correctly, this change resolves that.