### PR TITLE
Fixed memory leak stemming from long term storage of sound instances.…

### DIFF
--- a/src/soundjs/AbstractPlugin.js
+++ b/src/soundjs/AbstractPlugin.js
@@ -237,7 +237,10 @@ this.createjs = this.createjs || {};
 			this.preload(this.register(src));
 		}
 		var si = new this._soundInstanceClass(src, startTime, duration, this._audioSources[src]);
-		this._soundInstances[src].push(si);
+		if(this._soundInstances[src]){
+			this._soundInstances[src].push(si);
+		}
+
 		return si;
 	};
 
@@ -295,6 +298,7 @@ this.createjs = this.createjs || {};
 			var item = this._soundInstances[src][i];
 			item.setPlaybackResource(this._audioSources[src]);
 			// ToDo consider adding play call here if playstate == playfailed
+			this._soundInstances[src] = null;
 		}
 	};
 


### PR DESCRIPTION
… The _soundInstances array was only used for applying playback resources on a preload complete, so these arrays are now cleared out (and no longer used) after preloading finishes.