### PR TITLE
Proposed new features: filtering, distortion and convolution (reverb)

### DIFF
--- a/src/soundjs/AbstractSoundInstance.js
+++ b/src/soundjs/AbstractSoundInstance.js
@@ -218,6 +218,20 @@ this.createjs = this.createjs || {};
 		});
 
 		/**
+		 * The convolver buffer to use on the convolver node. This can be an audioBuffer or a filepath, and will be handled appropriately depending on which.
+		 * Note that convolver is not supported by HTML Audio.
+		 *
+		 * @property convolverBuffer
+		 * @type {String} || {AudioBuffer}
+		 * @default null
+		 */
+		this._convolverBuffer =  null;
+		Object.defineProperty(this, "convolverBuffer", {
+			get: this.getConvolverBuffer,
+			set: this.setConvolverBuffer
+		});
+
+		/**
 		 * Audio sprite property used to determine the starting offset.
 		 * @property startTime
 		 * @type {Number}
@@ -734,6 +748,44 @@ this.createjs = this.createjs || {};
 	p.getDistortionAmount = function () {
 		return this._distortionAmount;
 	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/convolverBuffer:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method setConvolverBuffer
+	 * @param {String} The filepath to an impulse response WAV || {AudioBuffer} The audio buffer to use as the convoler's buffer.
+	 * @return {AbstractSoundInstance} Returns reference to itself for chaining calls
+	 */
+	p.setConvolverBuffer = function (buffer) {
+		if (typeof buffer === 'string') {
+			//if a filepath is passed, must import it as an arraybuffer and decode
+			this._getConvolverBufferFromFilepath(buffer);
+		}
+		else {
+			if (typeof AudioBuffer !== 'undefined' && buffer instanceof AudioBuffer) {
+				//audio buffer is passed, set it directly
+				this._convolverBuffer = buffer;
+				this._updateConvolver();
+			}
+			else {
+				return false;
+			}
+		}
+		return this;
+	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/convolverBuffer:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method getConvolverBuffer
+	 * @return {AudioBuffer} The audio buffer being used as the convolver's buffer.
+	 */
+	p.getConvolverBuffer = function () {
+		return this._convolverBuffer;
+	};
+
 
 	/**
 	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/position:property"}}{{/crossLink}} directly as a property

--- a/src/soundjs/AbstractSoundInstance.js
+++ b/src/soundjs/AbstractSoundInstance.js
@@ -179,6 +179,19 @@ this.createjs = this.createjs || {};
 		});
 
 		/**
+		 * The filter type, one of the following: "lowpass" "highpass" bandpass". Note that filter is not supported by HTML Audio.
+		 *
+		 * @property filterType
+		 * @type {String}
+		 * @default "lowpass"
+		 */
+		this._filterType =  "lowpass";
+		Object.defineProperty(this, "filterType", {
+			get: this.getFilterType,
+			set: this.setFilterType
+		});
+
+		/**
 		 * Audio sprite property used to determine the starting offset.
 		 * @property startTime
 		 * @type {Number}
@@ -605,6 +618,41 @@ this.createjs = this.createjs || {};
 	 */
 	p.getFilterQ = function () {
 		return this._filterQ;
+	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterType:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method setFilterType
+	 * @param {String} The filter type, one of the following: "lowpass" "highpass" bandpass".
+	 * @return {AbstractSoundInstance} Returns reference to itself for chaining calls
+	 */
+	p.setFilterType = function (value) {
+		if(value == this._filterType) { return this; }
+
+		var acceptedTypes = {
+			"lowpass" : true,
+			"highpass" : true,
+			"bandpass" : true
+		};
+
+		if (typeof acceptedTypes[value] === 'undefined') { return false; }
+		
+		this._filterType = value;
+		this._updateFilter();
+		return this;
+	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterType:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method getFilterType
+	 * @return {String} The filter type, one of the following: "lowpass" "highpass" bandpass".
+	 */
+	p.getFilterType = function () {
+		return this._filterType;
 	};
 
 	/**

--- a/src/soundjs/AbstractSoundInstance.js
+++ b/src/soundjs/AbstractSoundInstance.js
@@ -153,6 +153,32 @@ this.createjs = this.createjs || {};
 		});
 
 		/**
+		 * The filter frequency of the sound, between 0 and half the sample rate. Note that filter is not supported by HTML Audio.
+		 *
+		 * @property filterFrequency
+		 * @type {Number}
+		 * @default 22050
+		 */
+		this._filterFrequency =  22050;
+		Object.defineProperty(this, "filterFrequency", {
+			get: this.getFilterFrequency,
+			set: this.setFilterFrequency
+		});
+
+		/**
+		 * The filter quality factor of the sound, between 0.0001 and 1000. Note that filter is not supported by HTML Audio.
+		 *
+		 * @property filterFrequency
+		 * @type {Number}
+		 * @default 1
+		 */
+		this._filterQ =  1;
+		Object.defineProperty(this, "filterQ", {
+			get: this.getFilterQ,
+			set: this.setFilterQ
+		});
+
+		/**
 		 * Audio sprite property used to determine the starting offset.
 		 * @property startTime
 		 * @type {Number}
@@ -527,6 +553,58 @@ this.createjs = this.createjs || {};
 	 */
 	p.getPan = function () {
 		return this._pan;
+	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterFrequency:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method setFilterFrequency
+	 * @param {Number} value The filter frequency value, between 0 and half the sample rate.
+	 * @return {AbstractSoundInstance} Returns reference to itself for chaining calls
+	 */
+	p.setFilterFrequency = function (value) {
+		if(value == this._filterFrequency) { return this; }
+		this._filterFrequency = value;
+		this._updateFilter();
+		return this;
+	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterFrequency:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method getFilterFrequency
+	 * @return {Number} The value of the filter frequency, between 0 and half the sample rate.
+	 */
+	p.getFilterFrequency = function () {
+		return this._filterFrequency;
+	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterQ:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method setFilterQ
+	 * @param {Number} value The filter quality factor, between 0.0001 and 1000.
+	 * @return {AbstractSoundInstance} Returns reference to itself for chaining calls
+	 */
+	p.setFilterQ = function (value) {
+		if(value == this._filterQ) { return this; }
+		this._filterQ = value;
+		this._updateFilter();
+		return this;
+	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterQ:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method getFilterQ
+	 * @return {Number} The value of the filter frequency, between 0.0001 and 1000.
+	 */
+	p.getFilterQ = function () {
+		return this._filterQ;
 	};
 
 	/**

--- a/src/soundjs/AbstractSoundInstance.js
+++ b/src/soundjs/AbstractSoundInstance.js
@@ -192,6 +192,19 @@ this.createjs = this.createjs || {};
 		});
 
 		/**
+		 * The filter detune value in cents. Note that filter is not supported by HTML Audio.
+		 *
+		 * @property filterDetune
+		 * @type {Number}
+		 * @default 0
+		 */
+		this._filterDetune =  0;
+		Object.defineProperty(this, "filterDetune", {
+			get: this.getFilterDetune,
+			set: this.setFilterDetune
+		});
+
+		/**
 		 * Audio sprite property used to determine the starting offset.
 		 * @property startTime
 		 * @type {Number}
@@ -638,8 +651,35 @@ this.createjs = this.createjs || {};
 		};
 
 		if (typeof acceptedTypes[value] === 'undefined') { return false; }
-		
+
 		this._filterType = value;
+		this._updateFilter();
+		return this;
+	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterDetune:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method getFilterDetune
+	 * @return {Number} The filter detune value in cents.
+	 */
+	p.getFilterDetune= function () {
+		return this._filterDetune;
+	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterDetune:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method setFilterDetune
+	 * @param {Number} The filter detune value in cents.
+	 * @return {AbstractSoundInstance} Returns reference to itself for chaining calls
+	 */
+	p.setFilterDetune = function (value) {
+		if(value == this._filterDetune) { return this; }
+
+		this._filterDetune= value;
 		this._updateFilter();
 		return this;
 	};

--- a/src/soundjs/AbstractSoundInstance.js
+++ b/src/soundjs/AbstractSoundInstance.js
@@ -205,6 +205,19 @@ this.createjs = this.createjs || {};
 		});
 
 		/**
+		 * The distortion value in amount. Note that distortion is not supported by HTML Audio.
+		 *
+		 * @property distortionAmount
+		 * @type {Number}
+		 * @default 0
+		 */
+		this._distortionAmount =  0;
+		Object.defineProperty(this, "distortionAmount", {
+			get: this.getDistortionAmount,
+			set: this.setDistortionAmount
+		});
+
+		/**
 		 * Audio sprite property used to determine the starting offset.
 		 * @property startTime
 		 * @type {Number}
@@ -658,14 +671,14 @@ this.createjs = this.createjs || {};
 	};
 
 	/**
-	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterDetune:property"}}{{/crossLink}} directly as a property
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterType:property"}}{{/crossLink}} directly as a property
 	 *
 	 * @deprecated
-	 * @method getFilterDetune
-	 * @return {Number} The filter detune value in cents.
+	 * @method getFilterType
+	 * @return {String} The filter type, one of the following: "lowpass" "highpass" bandpass".
 	 */
-	p.getFilterDetune= function () {
-		return this._filterDetune;
+	p.getFilterType = function () {
+		return this._filterType;
 	};
 
 	/**
@@ -685,14 +698,41 @@ this.createjs = this.createjs || {};
 	};
 
 	/**
-	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterType:property"}}{{/crossLink}} directly as a property
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/filterDetune:property"}}{{/crossLink}} directly as a property
 	 *
 	 * @deprecated
-	 * @method getFilterType
-	 * @return {String} The filter type, one of the following: "lowpass" "highpass" bandpass".
+	 * @method getFilterDetune
+	 * @return {Number} The filter detune value in cents.
 	 */
-	p.getFilterType = function () {
-		return this._filterType;
+	p.getFilterDetune = function () {
+		return this._filterDetune;
+	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/distortionAmount:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method setDistortionAmount
+	 * @param {Number} The distortion value in amount.
+	 * @return {AbstractSoundInstance} Returns reference to itself for chaining calls
+	 */
+	p.setDistortionAmount = function (value) {
+		if(value == this._distortionAmount) { return this; }
+
+		this._distortionAmount = value;
+		this._updateDistortion();
+		return this;
+	};
+
+	/**
+	 * DEPRECATED, please use {{#crossLink "AbstractSoundInstance/distortionAmount:property"}}{{/crossLink}} directly as a property
+	 *
+	 * @deprecated
+	 * @method getDistortionAmount
+	 * @return {Number} The distortion value in amount.
+	 */
+	p.getDistortionAmount = function () {
+		return this._distortionAmount;
 	};
 
 	/**

--- a/src/soundjs/webaudio/WebAudioSoundInstance.js
+++ b/src/soundjs/webaudio/WebAudioSoundInstance.js
@@ -209,6 +209,7 @@ this.createjs = this.createjs || {};
 	p._updateFilter = function() {
 		this.filterNode.frequency.value = this._filterFrequency;
 		this.filterNode.Q.value = this._filterQ;
+		this.filterNode.type = this._filterType;
 	};
 
 	p._removeLooping = function(value) {

--- a/src/soundjs/webaudio/WebAudioSoundInstance.js
+++ b/src/soundjs/webaudio/WebAudioSoundInstance.js
@@ -80,13 +80,24 @@ this.createjs = this.createjs || {};
 
 		/**
 		 * NOTE this is only intended for use by advanced users.
-		 * <br />A filterNode allowing frequency filtering. Connected to WebAudioSoundInstance {{#crossLink "WebAudioSoundInstance/panNode:property"}}{{/crossLink}}.
+		 * <br />A  ConvolverNode allowing application of convolver buffers (e.g. reverb) Connected to WebAudioSoundInstance {{#crossLink "WebAudioSoundInstance/panNode:property"}}{{/crossLink}}.
+		 * @property  convolverNode
+		 * @type { ConvolverNode}
+		 * @since 0.6.?
+		 */
+		this.convolverNode = s.context.createConvolver();
+		this.convolverNode.buffer = this.testBuffer;
+		this.convolverNode.connect(this.panNode); //convolver node => pan node => gain node
+
+		/**
+		 * NOTE this is only intended for use by advanced users.
+		 * <br />A filterNode allowing frequency filtering. Connected to WebAudioSoundInstance {{#crossLink "WebAudioSoundInstance/convolverNode:property"}}{{/crossLink}}.
 		 * @property filterNode
 		 * @type {BiquadFilterNode}
 		 * @since 0.6.?
 		 */
 		this.filterNode = s.context.createBiquadFilter();
-		this.filterNode.connect(this.panNode); //filter node => pan node => gain node
+		this.filterNode.connect(this.convolverNode); //filter node => convolver node => pan node => gain node
 
 		/**
 		 * NOTE this is only intended for use by advanced users.
@@ -96,7 +107,7 @@ this.createjs = this.createjs || {};
 		 * @since 0.6.?
 		 */
 		this.distortionNode = s.context.createWaveShaper();
-		this.distortionNode.connect(this.filterNode); //distortion node => filter node => pan node => gain node
+		this.distortionNode.connect(this.filterNode); //distortion node => filter node => convolver node => pan node => gain node
 
 		/**
 		 * NOTE this is only intended for use by advanced users.
@@ -244,6 +255,27 @@ this.createjs = this.createjs || {};
 		this.distortionNode.curve = this._makeDistortionCurve(this._distortionAmount);
 	};
 
+	p._updateConvolver = function() {
+		this.convolverNode.buffer = this._convolverBuffer;
+	};
+
+	p._getConvolverBufferFromFilepath = function(filepath) {
+		// grab audio track via XHR for convolver node
+		var req = new XMLHttpRequest();
+		req.open('GET', filepath, true);
+		req.responseType = 'arraybuffer';
+
+		var self = this; //save this reference
+		req.onload = function() {
+		  var audioData = req.response;
+		  s.context.decodeAudioData(audioData, function(buffer) {
+		  	self._convolverBuffer = buffer;
+		  	self._updateConvolver();
+		    }, function(e){"Error with decoding audio data" + e.err});
+		}
+		req.send();
+	};
+
 	p._removeLooping = function(value) {
 		this._sourceNodeNext = this._cleanUpAudioNode(this._sourceNodeNext);
 	};
@@ -317,10 +349,13 @@ this.createjs = this.createjs || {};
 	 * @since 0.4.1
 	 */
 	p._createAndPlayAudioNode = function(startTime, offset) {
+		console.log('createandplayaudionode');
 		var audioNode = s.context.createBufferSource();
 		audioNode.buffer = this.playbackResource;
-		//audioNode.connect(this.panNode);
 		audioNode.connect(this.distortionNode);
+		//audioNode.connect(this.convolverNode);
+		console.log('connected to convolverNode');
+
 		var dur = this._duration * 0.001;
 		audioNode.startTime = startTime + dur;
 		audioNode.start(audioNode.startTime, offset+(this._startTime*0.001), dur - offset);

--- a/src/soundjs/webaudio/WebAudioSoundInstance.js
+++ b/src/soundjs/webaudio/WebAudioSoundInstance.js
@@ -210,6 +210,7 @@ this.createjs = this.createjs || {};
 		this.filterNode.frequency.value = this._filterFrequency;
 		this.filterNode.Q.value = this._filterQ;
 		this.filterNode.type = this._filterType;
+		this.filterNode.detune.value = this._filterDetune;
 	};
 
 	p._removeLooping = function(value) {

--- a/src/soundjs/webaudio/WebAudioSoundInstance.js
+++ b/src/soundjs/webaudio/WebAudioSoundInstance.js
@@ -80,6 +80,16 @@ this.createjs = this.createjs || {};
 
 		/**
 		 * NOTE this is only intended for use by advanced users.
+		 * <br />A filterNode allowing frequency filtering. Connected to WebAudioSoundInstance {{#crossLink "WebAudioSoundInstance/panNode:property"}}{{/crossLink}}.
+		 * @property filterNode
+		 * @type {BiquadFilterNode}
+		 * @since 0.6.?
+		 */
+		this.filterNode = s.context.createBiquadFilter();
+		this.filterNode.connect(this.panNode); //filter node => pan node => gain node
+
+		/**
+		 * NOTE this is only intended for use by advanced users.
 		 * <br />sourceNode is the audio source. Connected to WebAudioSoundInstance {{#crossLink "WebAudioSoundInstance/panNode:property"}}{{/crossLink}}.
 		 * @property sourceNode
 		 * @type {AudioNode}
@@ -196,6 +206,11 @@ this.createjs = this.createjs || {};
 		// z need to be -0.5 otherwise the sound only plays in left, right, or center
 	};
 
+	p._updateFilter = function() {
+		this.filterNode.frequency.value = this._filterFrequency;
+		this.filterNode.Q.value = this._filterQ;
+	};
+
 	p._removeLooping = function(value) {
 		this._sourceNodeNext = this._cleanUpAudioNode(this._sourceNodeNext);
 	};
@@ -271,7 +286,8 @@ this.createjs = this.createjs || {};
 	p._createAndPlayAudioNode = function(startTime, offset) {
 		var audioNode = s.context.createBufferSource();
 		audioNode.buffer = this.playbackResource;
-		audioNode.connect(this.panNode);
+		//audioNode.connect(this.panNode);
+		audioNode.connect(this.filterNode);
 		var dur = this._duration * 0.001;
 		audioNode.startTime = startTime + dur;
 		audioNode.start(audioNode.startTime, offset+(this._startTime*0.001), dur - offset);


### PR DESCRIPTION
Wanted to share an idea I had for the soundJs library to be able to support additional features such as: *_filtering, convolution (reverb) and distortion. *_ 

I've been working on an experimental sound project which needed these extra features, so I forked off the great soundjs library.   

Looking for feedback and/or if there is a better way to implement this.  I took the approach of adding to the audio node chain, which is by default in the original soundJs library as follows:  **pan => gain => destination**,   and is now:  **distortion => filter => convolver => pan => gain => destination**

I tried to follow the conventions for private / public methods, object setting/getting for these new features.

The **convolverBuffer** property can be set directly (as an AudioBuffer), or can be passed a string which is the filepath to an impulse response (essentially a .wav file recording of a loud impulse which tails off in the space).  If passed a **filepath**,  the code will recognize that and attempt to read the file into an AudioBuffer automatically.
