### PR TITLE
An iOS hack should only exist on iOS

### DIFF
--- a/build/config.json
+++ b/build/config.json
@@ -4,13 +4,13 @@
 
 		"../src/createjs/utils/extend.js",
 		"../src/createjs/utils/promote.js",
-		"../src/createjs/utils/IndexOf.js",
-		"../src/createjs/utils/Proxy.js",
+		"../src/createjs/utils/indexOf.js",
+		"../src/createjs/utils/proxy.js",
 		"../src/createjs/utils/BrowserDetect.js",
 		"../src/createjs/events/EventDispatcher.js",
 		"../src/createjs/events/Event.js",
-
 		"../src/createjs/events/ErrorEvent.js",
+
 		"../src/preloadjs/events/ProgressEvent.js",
 		"../src/preloadjs/data/LoadItem.js",
 		"../src/preloadjs/data/Methods.js",
@@ -32,9 +32,9 @@
 		"../src/soundjs/Sound.js",
 		"../src/soundjs/AbstractSoundInstance.js",
 		"../src/soundjs/AbstractPlugin.js",
-		"../src/soundjs/webAudio/WebAudioLoader.js",
-		"../src/soundjs/webAudio/WebAudioSoundInstance.js",
-		"../src/soundjs/webAudio/WebAudioPlugin.js",
+		"../src/soundjs/webaudio/WebAudioLoader.js",
+		"../src/soundjs/webaudio/WebAudioSoundInstance.js",
+		"../src/soundjs/webaudio/WebAudioPlugin.js",
     	"../src/soundjs/htmlaudio/HTMLAudioTagPool.js",
     	"../src/soundjs/htmlaudio/HTMLAudioSoundInstance.js",
     	"../src/soundjs/htmlaudio/HTMLAudioPlugin.js"

--- a/src/soundjs/webaudio/WebAudioSoundInstance.js
+++ b/src/soundjs/webaudio/WebAudioSoundInstance.js
@@ -237,7 +237,9 @@ this.createjs = this.createjs || {};
 			audioNode.disconnect(0);
 			// necessary to prevent leak on iOS Safari 7-9. will throw in almost all other
 			// browser implementations.
-			try { audioNode.buffer = s._scratchBuffer; } catch(e) {}
+			if ( createjs.BrowserDetect.isIOS ) {
+				try { audioNode.buffer = s._scratchBuffer; } catch(e) {}
+			}
 			audioNode = null;
 		}
 		return audioNode;


### PR DESCRIPTION
On Edge I received the following error message: 
![edgeerror](https://cloud.githubusercontent.com/assets/5354914/22286647/28fa6dfe-e2f0-11e6-8834-9362a6bf6b0a.png)
Unlike the spec, saying that this code should throw, Edge logs an error and does not throw.
So I figured the best approach to fix this is to only execute the hack on iOS ( it's only needed there according to the comment ).