### PR TITLE
Reordering Sound.js export and its `_initialize()` call.

### DIFF
--- a/src/Sound.js
+++ b/src/Sound.js
@@ -2,7 +2,7 @@ import Group from "./Group";
 import Sample from "./Sample";
 import { EventDispatcher } from "@createjs/core";
 
-class Sound {
+export default class Sound {
 
 	// Sets up all static class defaults. This function is immediately invoked below the Sound class definition to ensure it runs.
 	static _initialize() {
@@ -637,5 +637,3 @@ class Sound {
 }
 
 Sound._initialize();
-
-export default Sound;


### PR DESCRIPTION
The current version doesn't work in webpack, since it tries to create a reference to `Sound`, but the initialization for `Sound` includes creating instances of other classes (such as `AbstractAudioWrapper`) that require a reference to `Sound` which has yet to be created. By re-ordering the export so that it is exported *before* it is initialized, a reference for `Sound` exists for those classes requiring it in `Sound`'s `_initialize()` invocation.