### PR TITLE
Fix basePath edge-case in registerSound

### DIFF
--- a/src/soundjs/Sound.js
+++ b/src/soundjs/Sound.js
@@ -1017,13 +1017,13 @@ this.createjs = this.createjs || {};
 	s.registerSound = function (src, id, data, basePath, defaultPlayProps) {
 		var loadItem = {src: src, id: id, data:data, defaultPlayProps:defaultPlayProps};
 		if (src instanceof Object && src.src) {
-			basePath = id;
+			basePath = basePath;
 			loadItem = src;
 		}
 		loadItem = createjs.LoadItem.create(loadItem);
-		loadItem.path = basePath;
+		loadItem.path = basePath || '';
 
-		if (basePath != null && !(loadItem.src instanceof Object)) {loadItem.src = basePath + loadItem.src;}
+		if (basePath && !(loadItem.src instanceof Object)) {loadItem.src = basePath + loadItem.src;}
 
 		var loader = s._registerSound(loadItem);
 		if(!loader) {return false;}


### PR DESCRIPTION
When calling registerSound with an object for src, like for instance when handling a data URL with `{ src: { mp3: ... }, type: "sound" }`, the id would get set as a `basePath`, and some inconsistent treatment of falsy values would lead to the id getting prepended to the URL. This fixes things so that sounds can be registered with data URLs.

Fixes #120