### PR TITLE
docs: Fix simple typo, ammount -> amount

### DIFF
--- a/examples/Game/Ship.js
+++ b/examples/Game/Ship.js
@@ -101,7 +101,7 @@
 	}
 
 	p.accelerate = function () {
-		//increase push ammount for acceleration
+		//increase push amount for acceleration
 		this.thrust += this.thrust + 0.6;
 		if (this.thrust >= Ship.MAX_THRUST) {
 			this.thrust = Ship.MAX_THRUST;

--- a/examples/Game/SpaceRock.js
+++ b/examples/Game/SpaceRock.js
@@ -18,7 +18,7 @@
 	p.bounds;	//visual radial size
 	p.hit;		//average radial disparity
 	p.size;		//size value itself
-	p.spin;		//spin ammount
+	p.spin;		//spin amount
 	p.score;	//score value
 
 	p.vX;		//velocity X


### PR DESCRIPTION
There is a small typo in examples/Game/Ship.js, examples/Game/SpaceRock.js.

Should read `amount` rather than `ammount`.

