### PR TITLE
fix: fix iphone audio playback by adding loadedmetadata listener

### DIFF
--- a/src/preloadjs/loaders/AbstractMediaLoader.js
+++ b/src/preloadjs/loaders/AbstractMediaLoader.js
@@ -116,6 +116,8 @@ this.createjs = this.createjs || {};
 	 */
 	p._formatResult = function (loader) {
 		this._tag.removeEventListener && this._tag.removeEventListener("canplaythrough", this._loadedHandler);
+		this._tag.removeEventListener && this._tag.removeEventListener("loadedmetadata", this._loadedHandler);
+
 		this._tag.onstalled = null;
 		if (this._preferXHR) {
             var URL = window.URL || window.webkitURL;

--- a/src/preloadjs/net/MediaTagRequest.js
+++ b/src/preloadjs/net/MediaTagRequest.js
@@ -72,6 +72,9 @@ this.createjs = this.createjs || {};
 		// This will tell us when audio is buffered enough to play through, but not when its loaded.
 		// The tag doesn't keep loading in Chrome once enough has buffered, and we have decided that behaviour is sufficient.
 		this._tag.addEventListener && this._tag.addEventListener("canplaythrough", this._loadedHandler, false); // canplaythrough callback doesn't work in Chrome, so we use an event.
+		
+		// iOS fallback: canplaythrough doesn't always fire on iPhone, so loadedmetadata ensures the handler is called
+		this._tag.addEventListener && this._tag.addEventListener("loadedmetadata", this._loadedHandler, false);
 
 		this.TagRequest_load();
 	};
@@ -110,6 +113,8 @@ this.createjs = this.createjs || {};
 	// protected methods
 	p._clean = function () {
 		this._tag.removeEventListener && this._tag.removeEventListener("canplaythrough", this._loadedHandler);
+		this._tag.removeEventListener && this._tag.removeEventListener("loadedmetadata", this._loadedHandler, false);
+
 		this._tag.removeEventListener("stalled", this._stalledCallback);
 		this._tag.removeEventListener("progress", this._progressCallback);
 


### PR DESCRIPTION
## Problem
Audio was intermittently not playing on iPhone when using HTMLAudioPlugin.

## Root Cause
The `canplaythrough` event wasn't firing reliably on iPhone, which prevented the `_loadedHandler` from being invoked. This caused audio to fail loading silently without any error indication.

## Solution
Added `loadedmetadata` event listener as a fallback to ensure the load handler is called on iPhone where `canplaythrough` is unreliable.